### PR TITLE
quantile data type

### DIFF
--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -95,13 +95,13 @@ Based off of the unit in the target definition, every date would use a fixed uni
 
 ## Valid prediction types by target type
 
-| target type | data_type | point | bin | sample | named |
-|-------------|-----------|-------|-----|--------|-------|
-| continuous  |   float   |   x   |  x  |   x    |  (1)  |
-| discrete    |   int     |   x   |  x  |   x    |  (2)  |
-| nominal     |   text    |   x   |  x  |   x    |   -   |
-| binary      |  boolean  |   x   |  x  |   x    |   -   |
-| date        |   date    |   x   |  x  |   x    |   -   |
+| target type | data_type | point | bin | sample | named | quantile |
+|-------------|-----------|-------|-----|--------|-------|----------|
+| continuous  |   float   |   x   |  x  |   x    |  (1)  |    x     |
+| discrete    |   int     |   x   |  x  |   x    |  (2)  |    x     |
+| nominal     |   text    |   x   |  x  |   x    |   -   |    -     |
+| binary      |  boolean  |   x   |  x  |   x    |   -   |    -     |
+| date        |   date    |   x   |  x  |   x    |   -   |    x     |
 
 Legend:
 (1) = valid named distributions are `norm`, `lnorm`, `gamma`, `beta`
@@ -114,12 +114,14 @@ Legend:
 |---------------|--------------------|-------------|-----------|---------------------|------|-------|-----|
 | *continuous*  | point              | x           | x         | -                   | x(a) | -     | -   |
 |               | bin                | -           | -         | x                   | x    | x     | x   |
-|               | named              | -           | -         | x                   | x    | -     | x   |
 |               | sample             | -           | -         | x(b)                | x    | -     | x   |
+|               | named              | -           | -         | x                   | x    | -     | x   |
+|               | quantile           | ?           | ?         | ?                   | ?    | ?     | ?   |
 | *discrete*    | point              | x           | x         | -                   | x(a) | -     | -   |
 |               | bin                | -           | -         | x                   | x    | x     | x   |
-|               | named              | -           | -         | x                   | x    | -     | x   |
 |               | sample             | -           | -         | x(b)                | x    | -     | x   |
+|               | named              | -           | -         | x                   | x    | -     | x   |
+|               | quantile           | ?           | ?         | ?                   | ?    | ?     | ?   |
 | *nominal*     | point              | -           | -         | -                   | -    | -     | -   |
 |               | bin                | -           | -         | x                   | -    | x     | -   |
 |               | sample             | -           | -         | x                   | -    | x     | -   |
@@ -129,6 +131,7 @@ Legend:
 | *date*        | point              | x           | x         | -                   | x(a) | -     | -   |
 |               | bin                | -           | -         | x                   | x    | x     | x   |
 |               | sample             | -           | -         | x(b)                | x    | -     | x   |
+|               | quantile           | ?           | ?         | ?                   | ?    | ?     | ?   |
 
 * x(a) = CRPS is equivalent to abs error for point forecasts.
 * x(b) = log score is required to be computed by approximation

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -29,8 +29,8 @@ These tests are performed when a forecast is created or updated.
 
 ### `Bin` Prediction Elements
 
- - If a Bin Prediction Element exists, it should have >=1 Database Rows.
- - `|cat| = |prob|`. The number of elements in the `cat` and `prob` vectors should be identical.
+- If a Bin Prediction Element exists, it should have >=1 Database Rows.
+- `|cat| = |prob|`. The number of elements in the `cat` and `prob` vectors should be identical.
 - `cat` (i, f, t, d, b): Entries in the database rows in the `cat` column cannot be `“”`, `“NA”` or `NULL` (case does not matter). Entries in `cat` must be a subset of `Target.cats` from the target definition.
 - `prob` (f): [0, 1]. Entries in the database rows in the `prob` column must be numbers in [0, 1]. For one prediction element, the values within prob must sum to 1.0 (values within +/- 0.001 of 1 are acceptable).
 - The data format of `cat` should correspond or be translatable to the `type` as in the target definition.
@@ -75,6 +75,15 @@ Binomial    | 0<=p<=1   |   n>0     |    -
  - If a Sample Prediction Element exists, it should have >=1 Database Rows.
  - `sample` (i, f, t, d, b): Entries in the database rows in the `sample` column cannot be `“”`, `“NA”` or `NULL` (case does not matter).
  - The data format of `sample` should correspond or be translatable to the `type` as in the target definition.
+
+
+### `Quantile` Prediction Elements
+
+- If a Quantile Prediction Element exists, it should have >=1 Database Rows.
+- `|quantile| = |value|`. The number of elements in the `quantile` and `value` vectors should be identical.
+- `quantile` (f): [0, 1]. Entries in the database rows in the `quantile` column must be numbers in [0, 1]. `quantile`s must be unique.
+- `value` (i, f, d): Entries in `value` must be non-decreasing as quantiles increase. Entries in the database rows in the `value` column cannot be `“”`, `“NA”` or `NULL` (case does not matter). Entries in `value` must be a subset of `Target.cats` from the target definition. Entries in `value` must obey existing ranges for targets.
+- The data format of `value` should correspond or be translatable to the `type` as in the target definition.
 
 
 ## Tests for Predictions by Target Type

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -82,7 +82,7 @@ Binomial    | 0<=p<=1   |   n>0     |    -
 - If a Quantile Prediction Element exists, it should have >=1 Database Rows.
 - `|quantile| = |value|`. The number of elements in the `quantile` and `value` vectors should be identical.
 - `quantile` (f): [0, 1]. Entries in the database rows in the `quantile` column must be numbers in [0, 1]. `quantile`s must be unique.
-- `value` (i, f, d): Entries in `value` must be non-decreasing as quantiles increase. Entries in the database rows in the `value` column cannot be `“”`, `“NA”` or `NULL` (case does not matter). Entries in `value` must be a subset of `Target.cats` from the target definition. Entries in `value` must obey existing ranges for targets.
+- `value` (i, f, d): Entries in `value` must be non-decreasing as quantiles increase. Entries in the database rows in the `value` column cannot be `“”`, `“NA”` or `NULL` (case does not matter). Entries in `value` must obey existing ranges for targets.
 - The data format of `value` should correspond or be translatable to the `type` as in the target definition.
 
 

--- a/zoltar-predictions-examples.json
+++ b/zoltar-predictions-examples.json
@@ -33,6 +33,14 @@
         "prob": [0.3, 0.2, 0.5]
       }
     },
+    {"unit": "location2",
+      "target": "pct next week",
+      "class": "quantile",
+      "prediction": {
+        "quantile": [0.025, 0.25, 0.5, 0.75, 0.975],
+        "value": [1.0, 2.2, 2.2, 5.0, 50.0]
+      }
+    },
 
     {"unit": "location3",
       "target": "pct next week",
@@ -87,6 +95,14 @@
       "prediction": {
         "cat": [0, 2, 50],
         "prob": [0.0, 0.1, 0.9]
+      }
+    },
+    {"unit": "location3",
+      "target": "cases next week",
+      "class": "quantile",
+      "prediction": {
+        "quantile": [0.25, 0.75],
+        "value": [0, 50]
       }
     },
 
@@ -192,6 +208,14 @@
       "prediction": {
         "cat": ["2019-12-15", "2019-12-22", "2019-12-29", "2020-01-05"],
         "prob": [0.01, 0.05, 0.05, 0.89]
+      }
+    },
+    {"unit": "location2",
+      "target": "Season peak week",
+      "class": "quantile",
+      "prediction": {
+        "quantile": [0.5, 0.75, 0.975],
+        "value": ["2019-12-22", "2019-12-29", "2020-01-05"]
       }
     },
 


### PR DESCRIPTION
Here's my first pass at documenting the quantile data type. Things to review:

- *Tests for Prediction Elements by Prediction Class > `Quantile` Prediction Elements*: please double-check everything, esp. relationship to Target.cats and Target.range.

- *Tests for Predictions by Target Type > "continuous"*: Do we need anything about quantiles?
- *Tests for Predictions by Target Type > "discrete"*: ""
- *Tests for Predictions by Target Type > "date"* (section doesn't exist yet): ""

- *Tests for Prediction Elements by Target Type > "continuous"*: Do we need anything about quantiles?
- *Tests for Prediction Elements by Target Type > "discrete"*: ""
- *Tests for Prediction Elements by Target Type > "date"*: ""

- zoltar-predictions-examples.json: I made a naive first pass at this. Please check and edit to make correct/less contrived. I'm esp. concerned with target cats and range constraints.

Thanks!