### PR TITLE
adding note guiding the use of point vs. other types

### DIFF
--- a/docs/FileFormats.md
+++ b/docs/FileFormats.md
@@ -73,7 +73,7 @@ The `"predictions"` list contains objects for each prediction, and each object c
     - `"quantile"`: A quantile distribution with two paired columns: `quantile` and `value`.
     - `"mean"`, `"median"`, and `"mode"`: A numeric prediction with a single value key, indicating the summary statistic indicated by the name, e.g. the mean.
 
-> Note: Regarding using the `point` prediction type vs. `mean`, `median`, and `mode`, we strongly recommend adopting one of the latter types if possible. Doing so could help avoid future data analysis inconsistencies.
+> Note: Regarding using the `point` prediction type vs. `mean`, `median`, and `mode`, we strongly recommend adopting one of the latter types if possible. Doing so could help avoid future data analysis inconsistencies. For example, soliciting a specific type of point prediction can ensure that any scoring rule used to evaluate predictions is well-matched to that prediction type.
 
 To indicate a [Retracted prediction](ForecastVersions.md#retracted-predictions) in JSON files, by use `null` for the "prediction" value. For example:
 

--- a/docs/FileFormats.md
+++ b/docs/FileFormats.md
@@ -73,6 +73,8 @@ The `"predictions"` list contains objects for each prediction, and each object c
     - `"quantile"`: A quantile distribution with two paired columns: `quantile` and `value`.
     - `"mean"`, `"median"`, and `"mode"`: A numeric prediction with a single value key, indicating the summary statistic indicated by the name, e.g. the mean.
 
+> Note: Regarding using the `point` prediction type vs. `mean`, `median`, and `mode`, we strongly recommend adopting one of the latter types if possible. Doing so could help avoid future data analysis inconsistencies.
+
 To indicate a [Retracted prediction](ForecastVersions.md#retracted-predictions) in JSON files, by use `null` for the "prediction" value. For example:
 
 ```json
@@ -87,7 +89,7 @@ To indicate a [Retracted prediction](ForecastVersions.md#retracted-predictions) 
 
 ## Forecast data format (CSV)
 
-Zoltar supports uploading and downloading forecast data in a CSV format with the following columns. It helps to think of this format as an "exploded" version of the prediction elements in the JSON format, where each element expands into one or more rows. `named`, `point`, `mean`, `median`, and `mode` types expand into single rows, and `bin`, `sample`, and `quantile` types expand into one or more rows depending on the particular data. You can read more about prediction types on tje [data model page](DataModel.md).
+Zoltar supports uploading and downloading forecast data in a CSV format with the following columns. It helps to think of this format as an "exploded" version of the prediction elements in the JSON format, where each element expands into one or more rows. `named`, `point`, `mean`, `median`, and `mode` types expand into single rows, and `bin`, `sample`, and `quantile` types expand into one or more rows depending on the particular data. You can read more about prediction types on the [data model page](DataModel.md).
 
 Note that because different prediction types have different contents, the CSV rows are "sparse" in that not every row uses all columns (the unused ones are empty, i.e., `""`). However, the `unit`, `target`, and `class` columns are always non-empty. For example, a `point` row only uses the `value` column whereas a `quantile` row uses only the `value` and `quantile` columns. To learn more you can examine the example file [zoltar-predictions-examples.csv](https://github.com/reichlab/docs.zoltardata/blob/master/docs/zoltar-predictions-examples.csv), which contains the same data as [zoltar-predictions-examples.json](https://github.com/reichlab/docs.zoltardata/blob/master/docs/zoltar-predictions-examples.json), but in CSV format.
 


### PR DESCRIPTION
Trying to express the guidance that @nickreich and I discussed re: using the point type vs. others.

Addresses: [[depreciate point prediction type #377]](https://github.com/reichlab/forecast-repository/issues/377)